### PR TITLE
style: enforce global box sizing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -41,14 +41,22 @@
   --ring: 212.7 26.8% 83.9%;
 }
 
-* {
+*, *::before, *::after {
+  box-sizing: border-box;
   border-color: hsl(var(--border));
+}
+
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 body {
   color: hsl(var(--foreground));
   background: hsl(var(--background));
   font-family: 'DM Sans', sans-serif;
+  margin: 0;
+  padding: 0;
 }
 
 /* Custom scrollbar */


### PR DESCRIPTION
## Summary
- ensure pixel-perfect rendering by applying box-sizing globally and resetting default margins
- improve text rendering with font-smoothing defaults

## Testing
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6891b6e1eaf8832e9d99306ba44b4f56