### PR TITLE
feat: add single token DCA deposit and API endpoints

### DIFF
--- a/app/api/deposit/dual/route.ts
+++ b/app/api/deposit/dual/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { DepositService } from '../../../../lib/deposit-logic';
+import { DepositRequest } from '../../../../types';
+
+export async function POST(req: Request) {
+  const body = (await req.json()) as DepositRequest;
+  try {
+    const res = await DepositService.processDualDeposit(body);
+    return NextResponse.json({ success: true, data: res, timestamp: Date.now() });
+  } catch (e: any) {
+    return NextResponse.json({ success: false, error: e.message, timestamp: Date.now() }, { status: 400 });
+  }
+}

--- a/app/api/deposit/single-dca/route.ts
+++ b/app/api/deposit/single-dca/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { DepositService } from '../../../../lib/deposit-logic';
+import { DepositRequest } from '../../../../types';
+
+export async function POST(req: Request) {
+  const body = (await req.json()) as DepositRequest;
+  try {
+    const res = await DepositService.processSingleDca(body);
+    return NextResponse.json({ success: true, data: res, timestamp: Date.now() });
+  } catch (e: any) {
+    return NextResponse.json({ success: false, error: e.message, timestamp: Date.now() }, { status: 400 });
+  }
+}

--- a/app/api/pool/ratio/route.ts
+++ b/app/api/pool/ratio/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { PoolService } from '../../../../lib/deposit-logic';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const pair = searchParams.get('pair') || 'SUI-USDC';
+  const ratio = await PoolService.getPoolRatio(pair);
+  return NextResponse.json({ success: true, data: ratio, timestamp: Date.now() });
+}

--- a/app/api/wallet/balance/route.ts
+++ b/app/api/wallet/balance/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { WalletService } from '../../../../lib/deposit-logic';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const address = searchParams.get('address') || '';
+  const balances = await WalletService.getWalletBalances(address);
+  return NextResponse.json({ success: true, data: balances, timestamp: Date.now() });
+}


### PR DESCRIPTION
## Summary
- implement single-token DCA strategy with slippage checks in `DepositService`
- enable single-mode validation and deposit handling in `LiquidityManager`
- add mock API routes for wallet balances, pool ratio, dual deposits, and single DCA deposits

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6891b9293a70832ea30f283fa59317ca